### PR TITLE
#158815916 User can access only ride requests he/her created

### DIFF
--- a/server/controllers/usercontroller.js
+++ b/server/controllers/usercontroller.js
@@ -131,8 +131,8 @@ const controller = {
             message: 'This token is either wrong or has expired'
           });
         } else {
-          const sqlInsert = 'INSERT INTO public."Rides" ("driverId", "origin", "destination", "time", "allowStops", "avaliableSpace", "description") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *;';
-          const values = [req.body.driverId, req.body.origin, req.body.destination, req.body.time, req.body.allowStops, req.body.avaliableSpace, req.body.description];
+          const sqlInsert = 'INSERT INTO public."Rides" ("driverId", "origin", "destination", "time", "allowStops", "avaliableSpace", "description", "requests") VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *;';
+          const values = [req.body.driverId, req.body.origin, req.body.destination, req.body.time, req.body.allowStops, req.body.avaliableSpace, req.body.description, new Array()];
           client.query(sqlInsert, values, (error) => {
             if (error) {
               res.status(404).json({

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -26,7 +26,7 @@ describe('Server', () => {
       chai.request(server)
         .post('/api/v1/auth/login')
         .send({
-          emailAddress: 'FirstTestDriver@example.com',
+          emailAddress: 'SecondTestDriver@example.com',
           password: 'qwerty'
         })
         .end((err, res) => {
@@ -47,7 +47,7 @@ describe('Server', () => {
       chai.request(server)
         .post('/api/v1/auth/login')
         .send({
-          emailAddress: 'FirstTestDriver@example.com',
+          emailAddress: 'SecondTestDriver@example.com',
           password: 'qwy'
         })
         .end((err, res) => {
@@ -62,6 +62,7 @@ describe('Server', () => {
         .get('/api/v1/rides')
         .set('jwt', token)
         .end((err, res) => {
+          console.log(res.body.data.rides);
           expect(res.statusCode).to.equal(200);
           expect(res.body.data.rides[0]).to.have.property('id');
           expect(res.body.data.rides[0]).to.have.property('driverId');

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -62,7 +62,6 @@ describe('Server', () => {
         .get('/api/v1/rides')
         .set('jwt', token)
         .end((err, res) => {
-          console.log(res.body.data.rides);
           expect(res.statusCode).to.equal(200);
           expect(res.body.data.rides[0]).to.have.property('id');
           expect(res.body.data.rides[0]).to.have.property('driverId');


### PR DESCRIPTION
### What does this PR do?
Add a feature that ensures that users can only access ride requests that they have created
Ensure that the requests filed in the returned rides is an empty array when no request has been made
#### Description of Task to be completed?
The following endpoint have been updated:
`/api/v1/rides/:rideId/requests`
`/api/v1/users/rides`
#### How should this be manually tested?
Clone the repository first and start the server on a terminal with `npm run start`
  * Sign-in with postman using `/api/v1/auth/login` is you already have an account
  * Use the returned token to access the other endpoints as a header with key 'jwt'
  * Using postman, access the endpoints above from localhost:3000
#### Any background context you want to provide?
These improvements where implemented based on feedback from my LFA
#### What are the relevant pivotal tracker stories?
  #158815916